### PR TITLE
Arbeidsforhold endringer

### DIFF
--- a/src/app/connected-components/arbeidsforhold/AndreInntekter/AndreInntekter.tsx
+++ b/src/app/connected-components/arbeidsforhold/AndreInntekter/AndreInntekter.tsx
@@ -32,12 +32,14 @@ import { cleanupAnnenInntekt } from '../utils/cleanup';
 const cls = BEMHelper('andre-inntekter');
 
 interface ConnectProps {
+    skjulFørstegangstjeneste?: boolean;
     vedlegg: Attachment[];
     uploadAttachment: (attachment: Attachment) => void;
     deleteAttachment: (attachment: Attachment) => void;
 }
 
 type Props = ConnectProps & ModalFormProps<AnnenInntekt> & InjectedIntlProps;
+
 const AndreInntekter: FunctionComponent<Props> = (props) => {
     const {
         endre,
@@ -49,7 +51,8 @@ const AndreInntekter: FunctionComponent<Props> = (props) => {
         intl,
         uploadAttachment,
         deleteAttachment,
-        vedlegg
+        vedlegg,
+        skjulFørstegangstjeneste
     } = props;
 
     const countries = useMemo(() => getCountries(true, false, intl), [intl]);
@@ -94,10 +97,14 @@ const AndreInntekter: FunctionComponent<Props> = (props) => {
                                         value: AnnenInntektType.JOBB_I_UTLANDET,
                                         label: getMessage(intl, 'inntektstype.jobb_i_utlandet')
                                     },
-                                    {
-                                        value: AnnenInntektType.MILITÆRTJENESTE,
-                                        label: getMessage(intl, 'inntektstype.militær_eller_siviltjeneste')
-                                    }
+                                    ...(skjulFørstegangstjeneste
+                                        ? []
+                                        : [
+                                              {
+                                                  value: AnnenInntektType.MILITÆRTJENESTE,
+                                                  label: getMessage(intl, 'inntektstype.militær_eller_siviltjeneste')
+                                              }
+                                          ])
                                 ]}
                             />
                         </Block>

--- a/src/app/connected-components/arbeidsforhold/ArbeidSeksjon/ArbeidSeksjon.tsx
+++ b/src/app/connected-components/arbeidsforhold/ArbeidSeksjon/ArbeidSeksjon.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentClass, FunctionComponent, StatelessComponent, useState } from 'react';
+import React, { FunctionComponent, StatelessComponent, useState } from 'react';
 import { injectIntl, InjectedIntlProps, InjectedIntl } from 'react-intl';
 import { connect as formConnect, FieldArray } from 'formik';
 import get from 'lodash/get';
@@ -48,7 +48,7 @@ interface OwnProps<T> {
         info?: string;
     };
     summaryListElementComponent: StatelessComponent<ModalSummaryProps<T>>;
-    formComponent: ComponentClass<ModalFormProps<T>>;
+    renderForm: (props: ModalFormProps<T>) => React.ReactNode;
 }
 
 type OuterProps = OwnProps<any> & InjectedIntlProps;
@@ -131,15 +131,15 @@ const Arbeidsforholdseksjon: FunctionComponent<Props> = (props: Props) => {
                                 shouldCloseOnOverlayClick={false}
                                 contentLabel={getMessage(intl, `utenlandsopphold.modal.ariaLabel`)}
                                 onRequestClose={() => toggleModal(false)}>
-                                <props.formComponent
-                                    endre={endre}
-                                    element={endre ? elementer[currentIndex] : undefined}
-                                    onCancel={() => toggleModal(false)}
-                                    onAdd={(arbeidsforhold: Næring | AnnenInntekt) => {
+                                {props.renderForm({
+                                    endre,
+                                    element: endre ? elementer[currentIndex] : undefined,
+                                    onCancel: () => toggleModal(false),
+                                    onAdd: (arbeidsforhold: Næring | AnnenInntekt) => {
                                         endre ? replace(currentIndex, arbeidsforhold) : push(arbeidsforhold);
                                         toggleModal(false);
-                                    }}
-                                />
+                                    }
+                                })}
                             </Modal>
                         </div>
                     );

--- a/src/app/connected-components/arbeidsforhold/Arbeidsforhold.tsx
+++ b/src/app/connected-components/arbeidsforhold/Arbeidsforhold.tsx
@@ -36,6 +36,7 @@ import { Søknadsgrunnlag } from 'app/types/Søknad';
 import { Arbeidsforholdstype } from 'app/types/Tilrettelegging';
 
 import './arbeidsforhold.less';
+import { AnnenInntektType } from '../../types/AnnenInntekt';
 
 const cls = BEMHelper('arbeidsforhold');
 
@@ -71,6 +72,10 @@ const Arbeidsforhold: FunctionComponent<Props> = (props: Props) => {
         arbeidsforhold,
         intl
     );
+
+    const harLagtTilFørstegangstjeneste = søker.andreInntekterSiste10Mnd
+        ? søker.andreInntekterSiste10Mnd.some((i) => i.type === AnnenInntektType.MILITÆRTJENESTE)
+        : false;
 
     const visHarJobbetSomSelvstendigNæringsdrivendeSiste10MndSeksjon =
         harJobbetSomFrilansSiste10Mnd === false ||
@@ -162,7 +167,9 @@ const Arbeidsforhold: FunctionComponent<Props> = (props: Props) => {
                         infoboksTekst={<AnnenInntektSiste10MndHjelpeTekst intl={intl} />}
                         summaryListTitle={{ title: getMessage(intl, 'arbeidsforhold.andreInntekter.listetittel') }}
                         summaryListElementComponent={AndreInntekterListElement}
-                        renderForm={(formProps) => <AndreInntekter {...formProps} />}
+                        renderForm={(formProps) => (
+                            <AndreInntekter {...formProps} skjulFørstegangstjeneste={harLagtTilFørstegangstjeneste} />
+                        )}
                     />
                 </Block>
 

--- a/src/app/connected-components/arbeidsforhold/Arbeidsforhold.tsx
+++ b/src/app/connected-components/arbeidsforhold/Arbeidsforhold.tsx
@@ -149,7 +149,7 @@ const Arbeidsforhold: FunctionComponent<Props> = (props: Props) => {
                         infoboksTekst={<FormattedHTMLMessage id="arbeidsforhold.selvstendig.infoboxTekst" />}
                         summaryListTitle={{ title: getMessage(intl, 'arbeidsforhold.selvstendig.listetittel') }}
                         summaryListElementComponent={SelvstendigListElement}
-                        formComponent={SelvstendigNæringsdrivende}
+                        renderForm={(formProps) => <SelvstendigNæringsdrivende {...formProps} />}
                     />
                 </Block>
 
@@ -162,7 +162,7 @@ const Arbeidsforhold: FunctionComponent<Props> = (props: Props) => {
                         infoboksTekst={<AnnenInntektSiste10MndHjelpeTekst intl={intl} />}
                         summaryListTitle={{ title: getMessage(intl, 'arbeidsforhold.andreInntekter.listetittel') }}
                         summaryListElementComponent={AndreInntekterListElement}
-                        formComponent={AndreInntekter}
+                        renderForm={(formProps) => <AndreInntekter {...formProps} />}
                     />
                 </Block>
 

--- a/src/app/connected-components/arbeidsforhold/Frilans/FrilansOppdrag.tsx
+++ b/src/app/connected-components/arbeidsforhold/Frilans/FrilansOppdrag.tsx
@@ -2,10 +2,9 @@ import React, { FunctionComponent } from 'react';
 import { injectIntl, InjectedIntlProps, FormattedMessage } from 'react-intl';
 import { Formik, FormikProps } from 'formik';
 
-import { Utenlandsopphold, Oppholdstype } from 'app/types/InformasjonOmUtenlandsopphold';
+import { Utenlandsopphold } from 'app/types/InformasjonOmUtenlandsopphold';
 
 import BEMHelper from 'common/util/bem';
-import { Næring } from 'app/types/SelvstendigNæringsdrivende';
 import { Knapp, Hovedknapp } from 'nav-frontend-knapper';
 import Block from 'common/components/block/Block';
 import { isValid } from 'i18n-iso-countries';
@@ -15,20 +14,15 @@ import DatoInput from 'app/formik/wrappers/DatoInput';
 import { Undertittel } from 'nav-frontend-typografi';
 import Knapperad from 'common/components/knapperad/Knapperad';
 import DatoerInputLayout from 'common/components/layout/datoerInputLayout/DatoerInputLayout';
+import { ModalFormProps } from '../ArbeidSeksjon/ArbeidSeksjon';
+import { FrilansOppdrag } from '../../../types/FrilansInformasjon';
 
 import './frilansOppdrag.less';
 
 const cls = BEMHelper('frilansOppdrag');
 
-export interface ModalFormProps {
-    endre: boolean;
-    element?: any;
-    type: Oppholdstype;
-    onAdd: (næring: Næring) => void;
-    onCancel: () => void;
-}
+type Props = ModalFormProps<FrilansOppdrag> & InjectedIntlProps;
 
-type Props = ModalFormProps & InjectedIntlProps;
 const FrilansOppdrag: FunctionComponent<Props> = (props: Props) => {
     const { endre, onCancel, element = {}, onAdd, intl } = props;
 

--- a/src/app/connected-components/arbeidsforhold/Frilans/FrilansSpørsmål.tsx
+++ b/src/app/connected-components/arbeidsforhold/Frilans/FrilansSpørsmål.tsx
@@ -72,7 +72,7 @@ const FrilansSpørsmål: FunctionComponent<Props> = (props: Props) => {
                                     )}
                                     buttonLabel={getMessage(intl, 'leggtil')}
                                     summaryListElementComponent={FrilansListElement}
-                                    formComponent={FrilansOppdrag}
+                                    renderForm={(formProps) => <FrilansOppdrag {...formProps} />}
                                     summaryListTitle={{ title: getMessage(intl, 'arbeidsforhold.frilans.listetittel') }}
                                 />
                             </Block>


### PR DESCRIPTION
- Gjøre ArbeidSeksjon mer fleksibel ved å endre til renderProp i stedet for en formKomponent prop.
- Skjule førstegangstjeneste fra skjema dersom bruker allerede har lagt til det under annen inntekt