### PR TITLE
Fix: EROFS: read-only file system, open '/usr/src/app/dist/js/setting…

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: teamforeldrepenger
   labels:
     team: teamforeldrepenger
+  annotations:
+    nais.io/read-only-file-system: "false"
 spec:
 {{#if gcp}}
   accessPolicy:


### PR DESCRIPTION
Applikasjonen feiler under deploy pga følende feilmelding:

`[Error: EROFS: read-only file system, open '/usr/src/app/dist/js/settings.js'] {
  errno: -30,
  code: 'EROFS',
  syscall: 'open',
  path: '/usr/src/app/dist/js/settings.js'
}
`